### PR TITLE
Handle VPC creation automatically

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -1,9 +1,19 @@
-- name: Setup Python on RHEL8 hosts
+- name: Setup Python on RHEL8 and Ubuntu hosts
   hosts: [amd64_backing_appdb, amd64_backing_opsman, amd64_backing_oplog, amd64_backing_blockstore, aarch64_backing_services, amd64_rhel_8, aarch64_rhel_8]
-  gather_facts: false
+  gather_facts: false  # Prevent failure due to missing Python
   # vars:
   #   ansible_python_interpreter: /usr/libexec/platform-python 
 
-  tasks: 
-  - name: Add a python version that will work with ansible 2.17 clients (like a mac)
-    ansible.builtin.raw: sudo yum module install -y python39:3.9/common
+  tasks:
+    - name: Detect OS Family
+      ansible.builtin.raw: cat /etc/os-release | grep '^ID='
+      register: os_family
+      changed_when: false
+
+    - name: Install Python 3.9 on RHEL
+      ansible.builtin.raw: sudo yum module install -y python39:3.9/common
+      when: "'rhel' in os_family.stdout"
+
+    - name: Install Python 3.9 on Ubuntu
+      ansible.builtin.raw: sudo apt update && sudo apt install -y python3.9
+      when: "'ubuntu' in os_family.stdout"

--- a/ansible/install-databases.yml
+++ b/ansible/install-databases.yml
@@ -1,7 +1,17 @@
+- name: Set os_release
+  hosts: [amd64_backing_appdb, amd64_backing_oplog, amd64_backing_blockstore]
+  gather_facts: no
+  tasks:
+    - name: Read OS Release Info
+      raw: cat /etc/os-release
+      register: os_release
+      changed_when: false
+
 - name: Install MongoDB Database
   hosts: [amd64_backing_appdb, amd64_backing_oplog, amd64_backing_blockstore]
   gather_facts: yes
+  vars:
+    ansible_python_interpreter: >-
+      {{ '/usr/bin/python3.11' if 'SUSE' in hostvars[inventory_hostname]['os_release'].stdout or 'sles' in hostvars[inventory_hostname]['os_release'].stdout else '/usr/bin/python3.9' }}
   roles:
     - databases
-  vars:
-    ansible_python_interpreter: /usr/bin/python3.9

--- a/ansible/install-om.yml
+++ b/ansible/install-om.yml
@@ -1,6 +1,17 @@
-- name: Install MongoDB Database
+- name: Set os_release
+  hosts: [amd64_backing_opsman]
+  gather_facts: no
+  tasks:
+    - name: Read OS Release Info
+      raw: cat /etc/os-release
+      register: os_release
+      changed_when: false
+
+- name: Install Ops Manager
   hosts: [amd64_backing_opsman]
   gather_facts: yes
+  vars:
+    ansible_python_interpreter: >-
+      {{ '/usr/bin/python3.11' if 'SUSE' in hostvars[inventory_hostname]['os_release'].stdout or 'sles' in hostvars[inventory_hostname]['os_release'].stdout else '/usr/bin/python3.9' }}
   roles:
     - ops
-  

--- a/ansible/modify-om.yml
+++ b/ansible/modify-om.yml
@@ -1,6 +1,18 @@
+- name: Set os_release
+  hosts: [x86_backing_opsman]
+  gather_facts: no
+  tasks:
+    - name: Read OS Release Info
+      raw: cat /etc/os-release
+      register: os_release
+      changed_when: false
+
 - name: Install MongoDB Database
   hosts: [x86_backing_opsman]
   gather_facts: yes
+  vars:
+    ansible_python_interpreter: >-
+      {{ '/usr/bin/python3.11' if 'SUSE' in hostvars[inventory_hostname]['os_release'].stdout or 'sles' in hostvars[inventory_hostname]['os_release'].stdout else '/usr/bin/python3.9' }}
   roles:
     - ops-mod
   

--- a/ansible/roles/databases/tasks/rhel.yml
+++ b/ansible/roles/databases/tasks/rhel.yml
@@ -173,6 +173,9 @@
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   run_once: true
   changed_when: false
+  vars:
+    HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
 
 - name: Add Secondary Nodes to Replica Set
   ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.add(\"{{ item }}:27017\")'"

--- a/ansible/roles/databases/tasks/rhel.yml
+++ b/ansible/roles/databases/tasks/rhel.yml
@@ -80,6 +80,19 @@
     enabled: yes
   when: version == "db_7_0_latest"
 
+- name: CentOS, Add repositories into a file
+  become: true
+  become_user: root
+  yum_repository:
+    name: mongodb-enterprise-8.0
+    description: mongodb-enterprise-8.0
+    file: mongodb-enterprise-8.0
+    baseurl: https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/8.0/$basearch/
+    gpgkey: https://www.mongodb.org/static/pgp/server-8.0.asc
+    gpgcheck: yes
+    enabled: yes
+  when: version == "db_8_0_latest"
+
 - name: CentOS, Stop mongod if running/exists
   become: true
   become_user: root
@@ -137,20 +150,39 @@
   become: true
   become_user: root
   service: name=mongod state=started
-
-- name: mongod.conf enable replication 3
-  ansible.builtin.command: "mongo --eval 'rs.initiate()'"
-  run_once: true
-  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
-  vars:
-    HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
-  when: "HOST_COUNT | int >= 3"
   
-- name: mongod.conf enable replication 4
-  command: mongo --eval 'rs.add("{{ item }}:27017")'
+# mongo is replaced by mongosh since 5.0 versions
+- name: Detect Mongo shell (mongo or mongosh)
+  ansible.builtin.command: "bash -c 'command -v mongosh || command -v mongo'"
+  register: mongo_shell_path
+  changed_when: false
+  ignore_errors: true
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   run_once: true
+
+- name: Initiate Replica Set
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.initiate()'"
+  run_once: true
+  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   vars:
     HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
-  when: "HOST_COUNT | int >= 3"
-  loop: "{{ amd64_backing_appdb }}"
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
+
+- name: Wait for MongoDB Primary Election
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'while (!rs.status().myState || rs.status().myState !== 1) { sleep(1) }'"
+  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
+  run_once: true
+  changed_when: false
+
+- name: Add Secondary Nodes to Replica Set
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.add(\"{{ item }}:27017\")'"
+  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
+  run_once: true
+  register: rs_add_result
+  until: rs_add_result.rc == 0
+  retries: 5
+  delay: 2
+  vars:
+    HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
+  loop: "{{ groups['amd64_backing_appdb'] | difference([groups['amd64_backing_appdb'].0]) }}"

--- a/ansible/roles/databases/tasks/suse.yml
+++ b/ansible/roles/databases/tasks/suse.yml
@@ -128,6 +128,9 @@
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   run_once: true
   changed_when: false
+  vars:
+    HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
 
 - name: Add Secondary Nodes to Replica Set
   ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.add(\"{{ item }}:27017\")'"

--- a/ansible/roles/databases/tasks/suse.yml
+++ b/ansible/roles/databases/tasks/suse.yml
@@ -4,6 +4,23 @@
   ansible.builtin.rpm_key:
     state: present
     key: https://pgp.mongodb.com/server-6.0.asc
+  when: version == "db_6_0_latest"
+
+- name: SUSE, import repo key from MongoDB
+  become: true
+  become_user: root
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://pgp.mongodb.com/server-7.0.asc
+  when: version == "db_7_0_latest"
+
+- name: SUSE, import repo key from MongoDB
+  become: true
+  become_user: root
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://pgp.mongodb.com/server-8.0.asc
+  when: version == "db_8_0_latest"
 
 - name: SUSE, add MongoDB repository
   become: true
@@ -22,6 +39,15 @@
     repo: 'https://repo.mongodb.com/zypper/suse/15/mongodb-enterprise/7.0/x86_64/'
     state: present
   when: version == "db_7_0_latest"
+
+- name: SUSE, add MongoDB repository
+  become: true
+  become_user: root
+  community.general.zypper_repository:
+    name: mongodb
+    repo: 'https://repo.mongodb.com/zypper/suse/15/mongodb-enterprise/8.0/x86_64/'
+    state: present
+  when: version == "db_8_0_latest"
 
 - name: SUSE, stop mongod if running/exists
   become: true
@@ -80,19 +106,38 @@
   become_user: root
   service: name=mongod state=started
 
-- name: mongod.conf enable replication 3
-  ansible.builtin.command: "mongo --eval 'rs.initiate()'"
+# mongo is replaced by mongosh since 5.0 versions
+- name: Detect Mongo shell (mongo or mongosh)
+  ansible.builtin.command: "bash -c 'command -v mongosh || command -v mongo'"
+  register: mongo_shell_path
+  changed_when: false
+  ignore_errors: true
+  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
+  run_once: true
+
+- name: Initiate Replica Set
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.initiate()'"
   run_once: true
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   vars:
     HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
-  when: "HOST_COUNT | int >= 3"
-  
-- name: mongod.conf enable replication 4
-  command: mongo --eval 'rs.add("{{ item }}:27017")'
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
+
+- name: Wait for MongoDB Primary Election
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'while (!rs.status().myState || rs.status().myState !== 1) { sleep(1) }'"
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   run_once: true
+  changed_when: false
+
+- name: Add Secondary Nodes to Replica Set
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.add(\"{{ item }}:27017\")'"
+  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
+  run_once: true
+  register: rs_add_result
+  until: rs_add_result.rc == 0
+  retries: 5
+  delay: 2
   vars:
     HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
-  when: "HOST_COUNT | int >= 3"
-  loop: "{{ amd64_backing_appdb }}"
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
+  loop: "{{ groups['amd64_backing_appdb'] | difference([groups['amd64_backing_appdb'].0]) }}"

--- a/ansible/roles/databases/tasks/ubuntu.yml
+++ b/ansible/roles/databases/tasks/ubuntu.yml
@@ -148,6 +148,9 @@
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   run_once: true
   changed_when: false
+  vars:
+    HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
 
 - name: Add Secondary Nodes to Replica Set
   ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.add(\"{{ item }}:27017\")'"

--- a/ansible/roles/databases/tasks/ubuntu.yml
+++ b/ansible/roles/databases/tasks/ubuntu.yml
@@ -54,6 +54,25 @@
     update_cache: yes
   when: version == "db_7_0_latest"
 
+- name: Debian/Ubuntu, add apt-key
+  become: true
+  become_user: root
+  apt_key:
+    url: https://www.mongodb.org/static/pgp/server-8.0.asc
+    state: present
+  when: version == "db_8_0_latest"
+
+- name: Debian/Ubuntu, add apt repository
+  become: true
+  become_user: root
+  apt_repository:
+    repo: "deb [ arch=amd64,arm64,s390x ] http://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/8.0 multiverse"
+    state: present
+    filename: mongodb-enerprise
+    update_cache: yes
+  when: version == "db_8_0_latest"
+  
+
 - name: Debian/Ubuntu, install mongodb-enterprise
   become: true
   become_user: root
@@ -107,19 +126,38 @@
   become_user: root
   service: name=mongod state=started
 
-- name: mongod.conf enable replication 3
-  ansible.builtin.command: "mongo --eval 'rs.initiate()'"
+# mongo is replaced by mongosh since 5.0 versions
+- name: Detect Mongo shell (mongo or mongosh)
+  ansible.builtin.command: "bash -c 'command -v mongosh || command -v mongo'"
+  register: mongo_shell_path
+  changed_when: false
+  ignore_errors: true
+  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
+  run_once: true
+
+- name: Initiate Replica Set
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.initiate()'"
   run_once: true
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   vars:
     HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
-  when: "HOST_COUNT | int >= 3"
-  
-- name: mongod.conf enable replication 4
-  command: mongo --eval 'rs.add("{{ item }}:27017")'
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
+
+- name: Wait for MongoDB Primary Election
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'while (!rs.status().myState || rs.status().myState !== 1) { sleep(1) }'"
   delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
   run_once: true
+  changed_when: false
+
+- name: Add Secondary Nodes to Replica Set
+  ansible.builtin.command: "{{ mongo_shell_path.stdout }} --eval 'rs.add(\"{{ item }}:27017\")'"
+  delegate_to: "{{ groups['amd64_backing_appdb'].0 }}"
+  run_once: true
+  register: rs_add_result
+  until: rs_add_result.rc == 0
+  retries: 5
+  delay: 2
   vars:
     HOST_COUNT: "{{ groups['amd64_backing_appdb'] | length }}"
-  when: "HOST_COUNT | int >= 3"
-  loop: "{{ amd64_backing_appdb }}"
+  when: "HOST_COUNT | int >= 3 and mongo_shell_path.stdout != ''"
+  loop: "{{ groups['amd64_backing_appdb'] | difference([groups['amd64_backing_appdb'].0]) }}"

--- a/ansible/roles/extras/tasks/centos.yml
+++ b/ansible/roles/extras/tasks/centos.yml
@@ -153,11 +153,11 @@
     regexp: '^::1         localhost localhost.localdomain localhost6 localhost6.localdomain6'
     line: "{{ ansible_default_ipv4.address }} {{ amd64_backing_public.0 }}"
 
-- name: Install IPA server
-  become: true
-  become_user: root
-  shell: ipa-server-install --realm IDM.EXAMPLE.COM --ds-password password --admin-password password --skip-mem-check --unattended
-  when: freeipa == "install"
+# - name: Install IPA server
+#   become: true
+#   become_user: root
+#   shell: ipa-server-install --realm IDM.EXAMPLE.COM --ds-password password --admin-password password --skip-mem-check --unattended
+#   when: freeipa == "install"
 
 #- name: Create ops_admin LDAP user
 #  become: true

--- a/ansible/roles/extras/tasks/centos.yml
+++ b/ansible/roles/extras/tasks/centos.yml
@@ -19,18 +19,18 @@
   become_user: root
   shell: hostnamectl set-hostname {{amd64_backing_public.0}}
 
-# - name: RHEL 8 install IdM
-#   become: true
-#   become_user: root
-#   yum:
-#     name: "{{ packages }}"
-#     state: present
-#   vars:
-#     packages:
-#       - '@idm:DL1'
-#       - 'freeipa-server'
-#       - 'nginx'
-#   when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8'
+- name: RHEL 8 install IdM
+  become: true
+  become_user: root
+  yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - '@idm:DL1'
+      - 'freeipa-server'
+      - 'nginx'
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8'
 
 # - name: Enable EPEL Repository on CentOS 7
 #   become: true
@@ -153,11 +153,11 @@
     regexp: '^::1         localhost localhost.localdomain localhost6 localhost6.localdomain6'
     line: "{{ ansible_default_ipv4.address }} {{ amd64_backing_public.0 }}"
 
-# - name: Install IPA server
-#   become: true
-#   become_user: root
-#   shell: ipa-server-install --realm IDM.EXAMPLE.COM --ds-password password --admin-password password --skip-mem-check --unattended
-#   when: freeipa == "install"
+- name: Install IPA server
+  become: true
+  become_user: root
+  shell: ipa-server-install --realm IDM.EXAMPLE.COM --ds-password password --admin-password password --skip-mem-check --unattended
+  when: freeipa == "install"
 
 #- name: Create ops_admin LDAP user
 #  become: true

--- a/ansible/roles/extras/tasks/centos.yml
+++ b/ansible/roles/extras/tasks/centos.yml
@@ -2,30 +2,35 @@
   include_vars:
     file: vars/om-vars.yaml
 
-- name: Disable SELinux
+- name: Disable SELinux Enforcement
   become: true
-  become_user: root
-  ansible.posix.selinux:
-    policy: targeted
-    state: permissive
+  command: setenforce 0
+  changed_when: false
+
+- name: Permanently Disable SELinux (survives after a reboot)
+  become: true
+  replace:
+    path: /etc/selinux/config
+    regexp: '^SELINUX=enforcing'
+    replace: 'SELINUX=permissive'
 
 - name: Set hostname to internal ec2 address
   become: true
   become_user: root
   shell: hostnamectl set-hostname {{amd64_backing_public.0}}
 
-- name: RHEL 8 install IdM
-  become: true
-  become_user: root
-  yum:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
-      - '@idm:DL1'
-      - 'freeipa-server'
-      - 'nginx'
-  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8'
+# - name: RHEL 8 install IdM
+#   become: true
+#   become_user: root
+#   yum:
+#     name: "{{ packages }}"
+#     state: present
+#   vars:
+#     packages:
+#       - '@idm:DL1'
+#       - 'freeipa-server'
+#       - 'nginx'
+#   when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8'
 
 # - name: Enable EPEL Repository on CentOS 7
 #   become: true
@@ -72,6 +77,10 @@
 #         - ipa-server-dns         ## DNS addon
 #         - nginx                  ## Load-balancer
 #         - vim
+
+- name: Install nginx
+  command: yum install -y nginx
+  become: yes
 
 - name: CentOS, stop nginx
   become: true

--- a/ansible/roles/ops/tasks/rhel.yml
+++ b/ansible/roles/ops/tasks/rhel.yml
@@ -217,7 +217,7 @@
     marker: "# Instance Parameter Overrides"
   loop:
     - { setting: mms.ignoreInitialUiSetup, value: "true" }
-    - { setting: mms.centralUrl, value: "{{om_url.0}}" }
+    - { setting: mms.centralUrl, value: "{{ services_url.0 | default(om_url.0) }}" }
     # - { setting: automation.versions.source, value: mongodb }
     - { setting: mms.adminEmailAddr, value: no-reply@opsmanager.local }
     - { setting: mms.fromEmailAddr, value: no-reply@opsmanager.local }

--- a/ansible/roles/ops/tasks/rhel.yml
+++ b/ansible/roles/ops/tasks/rhel.yml
@@ -109,7 +109,9 @@
       om_6_0_22: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.22.100.20231229T1643Z.x86_64.rpm
       om_6_0_23: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.23.100.20240402T1837Z.x86_64.rpm
       om_6_0_24: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.24.100.20240712T1253Z.x86_64.rpm
-      om_6_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.24.100.20240712T1253Z.x86_64.rpm
+      om_6_0_25: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.25.100.20240807T1538Z.x86_64.rpm
+      om_6_0_26: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.26.100.20241029T1714Z.x86_64.rpm
+      om_6_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.26.100.20241029T1714Z.x86_64.rpm
       om_7_0_0: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.0.500.20231218T1955Z.x86_64.rpm
       om_7_0_1: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.1.500.20240105T0225Z.x86_64.rpm
       om_7_0_2: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.2.500.20240130T2055Z.x86_64.rpm
@@ -121,7 +123,16 @@
       om_7_0_8: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.8.500.20240627T1703Z.x86_64.rpm
       om_7_0_9: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.9.500.20240716T1703Z.x86_64.rpm
       om_7_0_10: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.10.500.20240731T2149Z.x86_64.rpm
-      om_7_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.10.500.20240731T2149Z.x86_64.rpm
+      om_7_0_11: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.11.500.20240830T1718Z.x86_64.rpm
+      om_7_0_12: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.12.500.20241029T1917Z.x86_64.rpm
+      om_7_0_13: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.13.500.20250109T1502Z.x86_64.rpm
+      om_7_0_14: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.14.500.20250121T1020Z.x86_64.rpm
+      om_7_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.14.500.20250121T1020Z.x86_64.rpm
+      om_8_0_0: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.0.500.20240924T1611Z.x86_64.rpm
+      om_8_0_1: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.1.500.20241030T1559Z.x86_64.rpm
+      om_8_0_2: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.2.500.20241205T1612Z.x86_64.rpm
+      om_8_0_3: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.3.500.20250109T2333Z.x86_64.rpm
+      om_8_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.3.500.20250109T2333Z.x86_64.rpm
     om_download_url: "{{ urls[version] }}"
   get_url:
     url: "{{ om_download_url }}"

--- a/ansible/roles/ops/tasks/suse.yml
+++ b/ansible/roles/ops/tasks/suse.yml
@@ -203,7 +203,7 @@
     marker: "# Instance Parameter Overrides"
   loop:
     - { setting: mms.ignoreInitialUiSetup, value: "true" }
-    - { setting: mms.centralUrl, value: "{{om_url.0}}" }
+    - { setting: mms.centralUrl, value: "{{ services_url.0 | default(om_url.0) }}" }
     # - { setting: automation.versions.source, value: mongodb }
     - { setting: mms.adminEmailAddr, value: no-reply@opsmanager.local }
     - { setting: mms.fromEmailAddr, value: no-reply@opsmanager.local }

--- a/ansible/roles/ops/tasks/suse.yml
+++ b/ansible/roles/ops/tasks/suse.yml
@@ -109,7 +109,9 @@
       om_6_0_22: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.22.100.20231229T1643Z.x86_64.rpm
       om_6_0_23: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.23.100.20240402T1837Z.x86_64.rpm
       om_6_0_24: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.24.100.20240712T1253Z.x86_64.rpm
-      om_6_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.24.100.20240712T1253Z.x86_64.rpm
+      om_6_0_25: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.25.100.20240807T1538Z.x86_64.rpm
+      om_6_0_26: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.26.100.20241029T1714Z.x86_64.rpm
+      om_6_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-6.0.26.100.20241029T1714Z.x86_64.rpm
       om_7_0_0: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.0.500.20231218T1955Z.x86_64.rpm
       om_7_0_1: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.1.500.20240105T0225Z.x86_64.rpm
       om_7_0_2: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.2.500.20240130T2055Z.x86_64.rpm
@@ -121,7 +123,16 @@
       om_7_0_8: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.8.500.20240627T1703Z.x86_64.rpm
       om_7_0_9: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.9.500.20240716T1703Z.x86_64.rpm
       om_7_0_10: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.10.500.20240731T2149Z.x86_64.rpm
-      om_7_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.10.500.20240731T2149Z.x86_64.rpm
+      om_7_0_11: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.11.500.20240830T1718Z.x86_64.rpm
+      om_7_0_12: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.12.500.20241029T1917Z.x86_64.rpm
+      om_7_0_13: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.13.500.20250109T1502Z.x86_64.rpm
+      om_7_0_14: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.14.500.20250121T1020Z.x86_64.rpm
+      om_7_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-7.0.14.500.20250121T1020Z.x86_64.rpm
+      om_8_0_0: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.0.500.20240924T1611Z.x86_64.rpm
+      om_8_0_1: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.1.500.20241030T1559Z.x86_64.rpm
+      om_8_0_2: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.2.500.20241205T1612Z.x86_64.rpm
+      om_8_0_3: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.3.500.20250109T2333Z.x86_64.rpm
+      om_8_0_latest: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-8.0.3.500.20250109T2333Z.x86_64.rpm
     om_download_url: "{{ urls[version] }}"
   get_url:
     url: "{{ om_download_url }}"

--- a/ansible/roles/ops/tasks/ubuntu.yml
+++ b/ansible/roles/ops/tasks/ubuntu.yml
@@ -105,7 +105,7 @@
     marker: "# Instance Parameter Overrides"
   loop:
     - { setting: mms.ignoreInitialUiSetup, value: "true" }
-    - { setting: mms.centralUrl, value: "{{om_url.0}}" }
+    - { setting: mms.centralUrl, value: "{{ services_url.0 | default(om_url.0) }}" }
     # - { setting: automation.versions.source, value: mongodb }
     - { setting: mms.adminEmailAddr, value: no-reply@opsmanager.local }
     - { setting: mms.fromEmailAddr, value: no-reply@opsmanager.local }

--- a/ansible/roles/ops/tasks/ubuntu.yml
+++ b/ansible/roles/ops/tasks/ubuntu.yml
@@ -30,7 +30,9 @@
       om_6_0_22: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-6.0.22.100.20231229T1643Z.amd64.deb
       om_6_0_23: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-6.0.23.100.20240402T1833Z.amd64.deb
       om_6_0_24: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-6.0.24.100.20240712T1254Z.amd64.deb
-      om_6_0_latest: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-6.0.24.100.20240712T1254Z.amd64.deb
+      om_6_0_25: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-6.0.25.100.20240807T1537Z.amd64.deb
+      om_6_0_26: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-6.0.26.100.20241029T1712Z.amd64.deb
+      om_6_0_latest: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-6.0.26.100.20241029T1712Z.amd64.deb
       om_7_0_0: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.0.500.20231218T1951Z.amd64.deb
       om_7_0_1: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.1.500.20240105T0224Z.amd64.deb
       om_7_0_2: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.2.500.20240130T2116Z.amd64.deb
@@ -42,7 +44,16 @@
       om_7_0_8: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.8.500.20240627T1700Z.amd64.deb
       om_7_0_9: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.9.500.20240716T1711Z.amd64.deb
       om_7_0_10: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.10.500.20240731T2147Z.amd64.deb
-      om_7_0_latest: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.10.500.20240731T2147Z.amd64.deb
+      om_7_0_11: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.11.500.20240830T1726Z.amd64.deb
+      om_7_0_12: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.12.500.20241029T1928Z.amd64.deb
+      om_7_0_13: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.13.500.20250109T1452Z.amd64.deb
+      om_7_0_14: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.14.500.20250121T1019Z.amd64.deb
+      om_7_0_latest: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-7.0.14.500.20250121T1019Z.amd64.deb
+      om_8_0_0: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-8.0.0.500.20240924T1615Z.amd64.deb
+      om_8_0_1: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-8.0.1.500.20241030T1533Z.amd64.deb
+      om_8_0_2: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-8.0.2.500.20241205T1549Z.amd64.deb
+      om_8_0_3: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-8.0.3.500.20250109T2333Z.amd64.deb
+      om_8_0_latest: https://downloads.mongodb.com/on-prem-mms/deb/mongodb-mms-8.0.3.500.20250109T2333Z.amd64.deb
     om_download_url: "{{ urls[version] }}"
   get_url:
     url: "{{ om_download_url }}"

--- a/ansible/roles/tasks/centos.yml
+++ b/ansible/roles/tasks/centos.yml
@@ -140,7 +140,7 @@
     marker: "# Instance Parameter Overrides"
   loop:
     - { setting: mms.ignoreInitialUiSetup, value: "true" }
-    - { setting: mms.centralUrl, value: "{{om_url.0}}" }
+    - { setting: mms.centralUrl, value: "{{ services_url.0 | default(om_url.0) }}" }
     - { setting: automation.versions.source, value: mongodb }
     - { setting: mms.adminEmailAddr, value: no-reply@opsmanager.local }
     - { setting: mms.fromEmailAddr, value: no-reply@opsmanager.local }

--- a/main.tf
+++ b/main.tf
@@ -654,6 +654,7 @@ resource "local_file" "ansible_vars" {
     {
       appdb = (length(aws_instance.amd64_backing_appdb) > 0 ? [for vps in aws_instance.amd64_backing_appdb: vps.private_ip] : [for vps in aws_instance.amd64_backing_opsman: vps.private_ip]) 
       om_url = ((length(aws_instance.amd64_backing_opsman) > 0) ? "http://${aws_instance.amd64_backing_opsman["om1"].public_dns}:8080" : local.cloudmanager)
+      services_url = "http://${aws_instance.aarch64_backing_services["services"].public_dns}:3000"
       amd64_backing_private = [for vps in aws_instance.aarch64_backing_services: vps.private_dns]
       amd64_backing_public = [for vps in aws_instance.aarch64_backing_services: vps.public_dns]
     }

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,6 @@ resource "aws_subnet" "created_subnet" {
   count  = local.create_vpc ? 1 : 0
   vpc_id = aws_vpc.created_vpc[0].id
   cidr_block = "10.0.1.0/24"
-  availability_zone = "eu-west-1a"
   map_public_ip_on_launch = true # Automatically assign public IPs to instances
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ locals {
   amd64_backing_opsman = toset(["om1"])
 
   # LDAP/Kerberos/Load-Balancer infrastructure
-  aarch64_backing_services = toset(["services"]) # empty or "services"
+  aarch64_backing_services = toset([]) # empty or "services"
 
   # amd64 Deployments
   amd64_amazon_linux_2 = toset([])
@@ -654,7 +654,7 @@ resource "local_file" "ansible_vars" {
     {
       appdb = (length(aws_instance.amd64_backing_appdb) > 0 ? [for vps in aws_instance.amd64_backing_appdb: vps.private_ip] : [for vps in aws_instance.amd64_backing_opsman: vps.private_ip]) 
       om_url = ((length(aws_instance.amd64_backing_opsman) > 0) ? "http://${aws_instance.amd64_backing_opsman["om1"].public_dns}:8080" : local.cloudmanager)
-      services_url = "http://${aws_instance.aarch64_backing_services["services"].public_dns}:3000"
+      services_url = (length(aws_instance.aarch64_backing_services) > 0 ? "http://${aws_instance.aarch64_backing_services["services"].public_dns}:3000" : "")
       amd64_backing_private = [for vps in aws_instance.aarch64_backing_services: vps.private_dns]
       amd64_backing_public = [for vps in aws_instance.aarch64_backing_services: vps.public_dns]
     }

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -20,11 +20,11 @@ ansible-playbook -i ansible/inventory.ini \
 
 echo "Installing Application Database"
 ansible-playbook -i ansible/inventory.ini \
-                 -e 'version=db_6_0_latest' \
+                 -e 'version=db_7_0_latest' \
                  ansible/install-databases.yml
 
 echo "Installing Ops Manager"
 ansible-playbook -i ansible/inventory.ini \
-                 -e 'version=om_7_0_latest' \
+                 -e 'version=om_8_0_latest' \
                  -e 'ldap=false' \
                  ansible/install-om.yml

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -28,3 +28,5 @@ ansible-playbook -i ansible/inventory.ini \
                  -e 'version=om_8_0_latest' \
                  -e 'ldap=false' \
                  ansible/install-om.yml
+
+echo "Quick Setup Completed. If you are running a HA Ops Manager setup, consider running 'ansible-playbook -i ansible/inventory.ini ansible/install-extras.yml' to install nginx and other services."

--- a/settings.template
+++ b/settings.template
@@ -14,7 +14,7 @@ locals {
 
   # The **default** AWS VPC in which to create your security group
   # Blank if you want the VPC created for you (recommended)
-  default_vpc_id = "vpc-1a1a1a11a11aa1a1a1"
+  default_vpc_id = ""
 
   # The IP Address or CIDRs you want to give access to the created machines
   cidr_blocks = toset(

--- a/settings.template
+++ b/settings.template
@@ -12,7 +12,8 @@ locals {
   # A tag that is used to indicate when the machine can be deleted (I have a script to do this)
   tag_keep_until = formatdate("YYYY-MM-DD", timeadd(timestamp(), "25h"))
 
-  # The VPC in which to create your security group
+  # The **default** AWS VPC in which to create your security group
+  # Blank if you want the VPC created for you (recommended)
   default_vpc_id = "vpc-1a1a1a11a11aa1a1a1"
 
   # The IP Address or CIDRs you want to give access to the created machines

--- a/template/om-vars.tpl
+++ b/template/om-vars.tpl
@@ -7,6 +7,9 @@ appdb:
 om_url:
   - ${ om_url }
 
+services_url:
+  - ${ services_url }
+
 amd64_backing_private:
 %{ for node in amd64_backing_private ~}
   - ${ node }

--- a/template/om-vars.tpl
+++ b/template/om-vars.tpl
@@ -8,7 +8,9 @@ om_url:
   - ${ om_url }
 
 services_url:
-  - ${ services_url }
+%{ if services_url != "" ~}
+  - ${services_url}
+%{ endif ~}
 
 amd64_backing_private:
 %{ for node in amd64_backing_private ~}


### PR DESCRIPTION
# Ticket

For internal tracking only: [CLOUDP-294357](https://jira.mongodb.org/browse/CLOUDP-294357)

# Description  

Handle VPC creation automatically.  

- Adds logic to create a new VPC, subnet, internet gateway, and route tables **only** if `default_vpc_id` is empty.  
- When `default_vpc_id` is provided, the script skips creating these resources and instead uses the user’s existing **default** VPC.  

# Testing  

- Verified that when a real `default_vpc_id` is provided, Terraform uses the existing default VPC, skipping new VPC/subnet/gateway/route creation, and only creates instances and the security group in the existing environment.  
- Verified that when `default_vpc_id` is empty, Terraform successfully creates all necessary resources.  
- Verified that SSH and communication between nodes work as expected.  
- Verified that cleanup is handled correctly in both modes.  